### PR TITLE
fix(api): rename CreateNewCommnentAsync to CreateNewCommentAsync

### DIFF
--- a/Controllers/CommentController.cs
+++ b/Controllers/CommentController.cs
@@ -32,7 +32,7 @@ public class CommentController(ICommentService commentService) : ControllerBase
         {
             if (ModelState.IsValid)
             {
-                var newCommentId = await commentService.CreateNewCommnentAsync(postId, dto);
+                var newCommentId = await commentService.CreateNewCommentAsync(postId, dto);
                 var locationUri = $"{Request.Scheme}://{Request.Host}/api/Comment/{newCommentId}";
                 return Created(locationUri, newCommentId);
             }

--- a/Services/Implementations/CommentService.cs
+++ b/Services/Implementations/CommentService.cs
@@ -22,7 +22,7 @@ public class CommentService(ApplicationDbContext context, IMapper mapper) : ICom
         throw new NotFoundException("Comment not found!!");
     }
 
-    public async Task<int> CreateNewCommnentAsync(int postId, CreateCommentDto newComment)
+    public async Task<int> CreateNewCommentAsync(int postId, CreateCommentDto newComment)
     {
         Post? post = await context.Posts.FirstOrDefaultAsync(c => c.Id == postId);
         if (post != null)

--- a/Services/Interfaces/ICommentService.cs
+++ b/Services/Interfaces/ICommentService.cs
@@ -5,7 +5,7 @@ namespace PostHubAPI.Services.Interfaces;
 public interface ICommentService
 {
     Task<ReadCommentDto> GetCommentAsync(int id);
-    Task<int> CreateNewCommnentAsync(int postId, CreateCommentDto newComment);
+    Task<int> CreateNewCommentAsync(int postId, CreateCommentDto newComment);
     Task DeleteCommentAsync(int id);
     Task<ReadCommentDto> EditCommentAsync(int id, EditCommentDto dto);
 }

--- a/issues/evergreen/007-typo-in-public-api-name.md
+++ b/issues/evergreen/007-typo-in-public-api-name.md
@@ -6,7 +6,7 @@ Low
 
 ## Description
 
-A public service method is named `CreateNewCommnentAsync` (typo), and the typo propagates through interface, implementation, and call sites. This reduces readability and maintainability.
+A public service method is named `CreateNewCommentAsync` (typo), and the typo propagates through interface, implementation, and call sites. This reduces readability and maintainability.
 
 ## Proposed Updates
 


### PR DESCRIPTION
## Summary
Rename `CreateNewCommnentAsync` to `CreateNewCommentAsync` in the public API surface.

## Related issue
Fixes #7